### PR TITLE
Update README and start-distributed with changes I had to make to get this to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Create app, add buildpacks, add Kafka add-on, modify configs, deploy to Heroku.
 ```sh
 $ heroku apps:create my-app
 
-$ heroku buildpacks:add --index 1 https://github.com/heroku/heroku-buildpack-apt
+$ heroku buildpacks:add --index 1 https://github.com/actionsprout/heroku-buildpack-apt
 $ heroku buildpacks:add heroku/jvm
 
 # Add a credit card to your account so you can create addons.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ heroku buildpacks:add heroku/jvm
 
 # Add a credit card to your account so you can create addons.
 
-$ heroku addons:create heroku-kafka:basic-0 --app my-app
+$ heroku addons:create heroku-kafka:standard-0
 
 $ git push heroku master
 
@@ -89,7 +89,7 @@ This repo leverages [Debezium](https://debezium.io/) to do CDC from Postgres int
 you will also need Heroku Postgres.
 
 ```
-$ heroku addons:create heroku-postgres:<plan>
+$ heroku addons:create heroku-postgres:standard-0
 ```
 
 Then,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repo serves as an example of how you can run Kafka Connect or KSQL on Herok
 Specifically, it demonstrates how fundamental Kafka components integrate well with the
 Heroku Runtime.
 
-Kafka Connect and KSQL, though not yet officially supported by Heroku, runs well on Heroku 
+Kafka Connect and KSQL, though not yet officially supported by Heroku, runs well on Heroku
 and works under both single- and multi-tenant Kafka plans.
 
 ## Architecture
@@ -25,7 +25,7 @@ to interact with.
 
 ### KSQL
 
-This runs on dynos as a distributed system. You can also scale dynos up or down. Rebalancing is taken 
+This runs on dynos as a distributed system. You can also scale dynos up or down. Rebalancing is taken
 care of here as well. KSQL also exposes a web port. This is because the `ksql` cli is essentially a
 read-eval-print-loop that communicates to the KSQL server(s), which communicate to Kafka brokers on
 your behalf. Essentially, you submit a KSQL query via REST and get a response. This response can be
@@ -56,7 +56,7 @@ additional KSQL dependencies, and starts the KSQL binary.
 All scripts are run on the dyno in Heroku.
 
 Notice this repo doesn't contain any code. This is because no code is necessary. Instead, all we have
-is configuration in the form of [demo-connector.json](https://github.com/jeffchao/bottled-water/blob/master/demo-connector.json) 
+is configuration in the form of [demo-connector.json](https://github.com/jeffchao/bottled-water/blob/master/demo-connector.json)
 which is used for Kafka Connect to specify Debezium and Connect properties. All that's required of us
 as the end user is to fill in this config file. More importantly, this file does not even need to be
 checked in, but is present in this repo as an example. This config file can be stored anywhere since
@@ -85,7 +85,7 @@ $ heroku ps:scale web=1
 
 ### Kafka Connect
 
-This repo leverages [Debezium](https://debezium.io/) to do CDC from Postgres into Kafka. For this process, 
+This repo leverages [Debezium](https://debezium.io/) to do CDC from Postgres into Kafka. For this process,
 you will also need Heroku Postgres.
 
 ```

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ $ heroku buildpacks:add heroku/jvm
 
 $ heroku addons:create heroku-kafka:standard-0
 
+# Add key passwords, please change these
+$ heroku config:set TRUSTSTORE_PASSWORD=changeme KEYSTORE_PASSWORD=changeme
+
 $ git push heroku master
 
 # Comment out or un-comment desired `web` dyno in the `Procfile` (or just deploy to separate apps)

--- a/start-distributed
+++ b/start-distributed
@@ -52,7 +52,7 @@ status.storage.replication.factor=1
 
 offset.flush.interval.ms=10000
 
-# These are provided to inform the user about the presence of the REST host and port configs 
+# These are provided to inform the user about the presence of the REST host and port configs
 # Hostname & Port for the REST API to listen on. If this is set, it will bind to the interface used to listen to requests.
 #rest.host.name=
 rest.port=$PORT
@@ -62,12 +62,12 @@ rest.port=$PORT
 #rest.advertised.port=
 
 # Set to a list of filesystem paths separated by commas (,) to enable class loading isolation for plugins
-# (connectors, converters, transformations). The list should consist of top level directories that include 
-# any combination of: 
+# (connectors, converters, transformations). The list should consist of top level directories that include
+# any combination of:
 # a) directories immediately containing jars with plugins and their dependencies
 # b) uber-jars with plugins and their dependencies
 # c) directories immediately containing the package directory structure of classes of plugins and their dependencies
-# Examples: 
+# Examples:
 # plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors,
 plugin.path=.apt/usr/share/java
 PROPERTIES

--- a/start-distributed
+++ b/start-distributed
@@ -42,13 +42,13 @@ internal.key.converter.schemas.enable=false
 internal.value.converter.schemas.enable=false
 
 offset.storage.topic=connect-offsets
-offset.storage.replication.factor=1
+offset.storage.replication.factor=3
 
 config.storage.topic=connect-configs
-config.storage.replication.factor=1
+config.storage.replication.factor=3
 
 status.storage.topic=connect-status
-status.storage.replication.factor=1
+status.storage.replication.factor=3
 
 offset.flush.interval.ms=10000
 

--- a/start-distributed
+++ b/start-distributed
@@ -3,7 +3,7 @@
 DYNO_CONNECT_DISTRIBUTED_PROPERTIES_FILE="dyno-connect-distributed.properties"
 DEBEZIUM_CONNECTOR_URL="https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/0.7.2/debezium-connector-postgres-0.7.2-plugin.tar.gz"
 
-./setup_certs HEROKU_KAFKA_JCHAO
+./setup_certs KAFKA
 
 cat > $DYNO_CONNECT_DISTRIBUTED_PROPERTIES_FILE <<PROPERTIES
 producer.security.protocol=SSL
@@ -27,7 +27,7 @@ ssl.keystore.location=$HOME/.keystore.jks
 ssl.keystore.password=$KEYSTORE_PASSWORD
 ssl.key.password=$KEYSTORE_PASSWORD
 
-bootstrap.servers=${HEROKU_KAFKA_JCHAO_URL//kafka+ssl:\/\//}
+bootstrap.servers=${KAFKA_URL//kafka+ssl:\/\//}
 
 group.id=connect-cluster
 


### PR DESCRIPTION
* Change KAFKA prefix to default

  When following the default setup steps, the ENV vars should have the most basic prefix, which should work for anyone starting from scratch. If you have more than one KAFKA addon, you might need to change the prefix...

* Add the setting of cert passwords to setup instructions

* Use my custom buildpack that sets up keys for installing confluent

  I ran in to a problem where the files in the Aptfile were not getting installed because apt didn't have a key to verify the signature of the confluent packages.

  <details>
  <summary>Without this buildpack, I saw the following errors on build</summary>

  <pre><code>
  remote: -----> Apt app detected
  remote: -----> Detected Aptfile changes, flushing cache
  remote: -----> Adding custom repositories
  remote: -----> Updating apt caches
  remote:        Get:1 http://packages.confluent.io/deb/4.0 stable InRelease [5,116 B]
  remote:        Get:2 http://archive.ubuntu.com/ubuntu bionic InRelease [242 kB]
  remote:        Err:1 http://packages.confluent.io/deb/4.0 stable InRelease
  remote:          The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 670540C841468433
  remote:        Get:3 http://apt.postgresql.org/pub/repos/apt xenial-pgdg InRelease [51.3 kB]
  remote:        Get:4 http://archive.ubuntu.com/ubuntu bionic-security InRelease [83.2 kB]
  remote:        Get:5 http://apt.postgresql.org/pub/repos/apt xenial-pgdg/main amd64 Packages [194 kB]
  remote:        Get:6 http://archive.ubuntu.com/ubuntu bionic-updates InRelease [88.7 kB]
  remote:        Get:7 http://archive.ubuntu.com/ubuntu bionic/main amd64 Packages [1,344 kB]
  remote:        Get:8 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages [11.3 MB]
  remote:        Get:9 http://archive.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [111 kB]
  remote:        Get:10 http://archive.ubuntu.com/ubuntu bionic-security/main amd64 Packages [235 kB]
  remote:        Get:11 http://archive.ubuntu.com/ubuntu bionic-updates/main amd64 Packages [536 kB]
  remote:        Get:12 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages [724 kB]
  remote:        Reading package lists...
  remote: W: GPG error: http://packages.confluent.io/deb/4.0 stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 670540C841468433
  remote: E: The repository 'http://packages.confluent.io/deb/4.0 stable InRelease' is not signed.
  remote: -----> Fetching .debs for confluent-kafka-2.11
  remote:        Reading package lists...
  remote:        Building dependency tree...
  remote: W: --force-yes is deprecated, use one of the options starting with --allow instead.
  remote: E: Unable to locate package confluent-kafka-2.11
  remote: E: Couldn't find any package by glob 'confluent-kafka-2.11'
  remote: E: Couldn't find any package by regex 'confluent-kafka-2.11'
  remote: -----> Fetching .debs for confluent-schema-registry
  remote:        Reading package lists...
  remote:        Building dependency tree...
  remote: W: --force-yes is deprecated, use one of the options starting with --allow instead.
  remote: E: Unable to locate package confluent-schema-registry
  remote: ls: cannot access '/app/tmp/cache/apt/cache/archives/*.deb': No such file or directory
  </code></pre>

  </details>

* Specify plans

  This setup requires kafka standard-0. It should be possible to run on basic-0, but these scripts do not yet support that.

  These scripts may not require postgres standard-0, but it seems worth doing and the price pales in comparison with kafka...

* Remove trailing whitespace

  Sorry about this somewhat noisy change; my editor is configured to do this and its just easier to include the change than try to ignore it every time.